### PR TITLE
Fix select inside quote w/ cursor just before end quote

### DIFF
--- a/lib/selector.coffee
+++ b/lib/selector.coffee
@@ -72,7 +72,7 @@ class Selector
               if isStartQuote(pos)
                 return pos
               else
-                return lookForwardOnLine(start)
+                return lookBackwardOnLine(start) or lookForwardOnLine(start)
           -- pos.column
         pos.column = -1
         -- pos.row
@@ -89,6 +89,15 @@ class Selector
       index = line.substring(pos.column).indexOf(char)
       if index >= 0
         pos.column += index
+        return pos
+      null
+
+    lookBackwardOnLine = (pos) ->
+      line = editor.lineTextForBufferRow(pos.row).substring(0,pos.column)
+
+      index = line.lastIndexOf(char)
+      if index >= 0
+        pos.column += index - line.length
         return pos
       null
 


### PR DESCRIPTION
Fixes the selection inside quote case where the cursor is right before an ending quote.

We should probably add some tests for selecting in quotes. I'm not sure how you'd want me to design the tests though. Let me know how to approach it if you need it.

Fixes #15 
